### PR TITLE
Fix async functions not supported by _.isFunction

### DIFF
--- a/middleware/swagger-router.js
+++ b/middleware/swagger-router.js
@@ -392,7 +392,7 @@ exports = module.exports = function (options) {
     _.each(options.controllers, function (func, handlerName) {
       debug('    %s', handlerName);
 
-      if (!_.isFunction(func)) {
+      if (typeof func !== 'function') {
         throw new Error('options.controllers values must be functions');
       }
     });


### PR DESCRIPTION
The _.isFunction uses `toString` and checks the string against `[object function]` to see if it's a function. This doesn't work with async functions.